### PR TITLE
Adjustment on the footer

### DIFF
--- a/themes/inlive/layouts/partials/footer/footer.html
+++ b/themes/inlive/layouts/partials/footer/footer.html
@@ -10,7 +10,7 @@
           <a href="mailto:technology@asumsi.co" target="_blank" rel="noopener noreferrer" class="text-gray-500">Contact</a>
         </li>
         <li class="mb-2 text-sm leading-6">
-          <a href="#pricing" class="text-gray-500">Pricing</a>
+          <a href="/#pricing" class="text-gray-500">Pricing</a>
         </li>
         <li class="text-sm leading-6">
           <a href="{{ .Site.Params.inliveStudioOrigin }}/login" class="text-gray-500">inLive Studio</a>


### PR DESCRIPTION
# Description
This PR is intended to fix this issue [#77](https://github.com/asumsi/inlive-website/issues/77)

- This will remove the links that don't point to actual URL (empty link)
- The contact link is pointing to technology@asumsi.co
- The pricing navigation in the footer is pointing to `#pricing` section in landing page. This pricing update is on the separated issue and hasn't been updated here. So, if you try to click the pricing link on the footer in the Cloudflare pages preview, it is still similar with the dead link because there is no pricing section yet.

<img width="1376" alt="Screen Shot 2022-03-28 at 08 16 22" src="https://user-images.githubusercontent.com/43695578/160310639-555502f3-ce59-42e1-989f-0e934e49074e.png">