### PR TITLE
Add "why us" and "use cases" navigation menu

### DIFF
--- a/themes/inlive/layouts/index.html
+++ b/themes/inlive/layouts/index.html
@@ -174,7 +174,7 @@
     </div>
     */}}
   </section>
-  <section class="mt-20">
+  <section id="why-us" class="mt-20">
     <div class="px-4 lg:px-20">
       <header class="max-w-7xl mx-auto lg:px-8 lg:pt-8 pb-8 lg:pb-16">
         <h2 class="mb-4 font-semibold text-base text-blue-600 uppercase flex items-center">
@@ -241,7 +241,7 @@
       </header>
     </div>
   </section>
-  <section class="mt-20">
+  <section id="use-cases" class="mt-20">
     <div class="px-4 lg:px-20">
       <header class="max-w-7xl mx-auto lg:px-8 lg:pt-8 pb-8 lg:pb-16">
         <h2 class="mb-4 font-semibold text-base text-blue-600 uppercase flex items-center">

--- a/themes/inlive/layouts/partials/navbar/mobile-navbar.html
+++ b/themes/inlive/layouts/partials/navbar/mobile-navbar.html
@@ -19,7 +19,13 @@
         <a href="/#what-we-offer" class="text-gray-700">What We Offer</a>
       </li>
       <li class="mb-6 font-semibold text-base">
+        <a href="/#why-us" class="text-gray-700">Why Us</a>
+      </li>
+      <li class="mb-6 font-semibold text-base">
         <a href="/#pricing" class="text-gray-700">Pricing</a>
+      </li>
+      <li class="mb-6 font-semibold text-base">
+        <a href="/#use-cases" class="text-gray-700">Use Cases</a>
       </li>
       <li class="mb-6 font-semibold text-base">
         <a href="/docs/introduction/" class="text-gray-700">Docs</a>

--- a/themes/inlive/layouts/partials/navbar/navbar.html
+++ b/themes/inlive/layouts/partials/navbar/navbar.html
@@ -7,7 +7,13 @@
       <a href="/#what-we-offer" class="inline-block text-gray-700 hover:text-blue-600">What We Offer</a>
     </li>
     <li class="mr-8 font-semibold text-sm leading-6">
+      <a href="/#why-us" class="inline-block text-gray-700 hover:text-blue-600">Why Us</a>
+    </li>
+    <li class="mr-8 font-semibold text-sm leading-6">
       <a href="/#pricing" class="inline-block text-gray-700 hover:text-blue-600">Pricing</a>
+    </li>
+    <li class="mr-8 font-semibold text-sm leading-6">
+      <a href="/#use-cases" class="inline-block text-gray-700 hover:text-blue-600">Use Cases</a>
     </li>
     <li class="mr-8 font-semibold text-sm leading-6">
       <a href="/docs/introduction/" class="inline-block text-gray-700 hover:text-blue-600">Docs</a>


### PR DESCRIPTION
# Description
This PR is intended to update and fix the checklists from this issue [#109](https://github.com/asumsi/inlive/issues/109)
- Add "why us" and "use cases" in the navigation menu in the header.

This preview can be seen on this URL https://e85ba4c7.inlive-website.pages.dev/