### PR TITLE
Style/pricing page

### DIFF
--- a/themes/inlive/layouts/page/pricing.html
+++ b/themes/inlive/layouts/page/pricing.html
@@ -146,7 +146,7 @@
             <span class="w-11/12 md:w-full">How can I know my billing?</span>
           </button>
           <div class="panel overflow-hidden text-left text-gray-600">
-            <p class="text-base leading-6 mt-3.5 mr-5 lg:mr-[3.75rem]">WWe will send you a billing statement after 1 cycle (30 days) has been finished via email. Due date applied 14 days after billing was issued.</p>
+            <p class="text-base leading-6 mt-3.5 mr-5 lg:mr-[3.75rem]">We will send you a billing statement after 1 cycle (30 days) has been finished via email. Due date applied 14 days after billing was issued.</p>
           </div>
         </div>
     </div>


### PR DESCRIPTION
**Description**
Small revision styling of pricing boxes on pricing page, based on issue [#119](https://github.com/asumsi/inlive-website/issues/119).

**Implementation**
- Not using box shadow when being hovered on the pricing box
- Using align items end so that the contact us buttons will be stayed on the end of box. Therefore, I made some revisions on the styling too so if inputing dynamic description value, the buttons will be stayed on the same position.