### PR TITLE
Enhancement : Add Bandwidth Pricing Info on FAQ Pricing Page

### DIFF
--- a/themes/inlive/layouts/page/pricing.html
+++ b/themes/inlive/layouts/page/pricing.html
@@ -149,6 +149,16 @@
             <p class="text-base leading-6 mt-3.5 mr-5 lg:mr-[3.75rem]">We will send you a billing statement after 1 cycle (30 days) has been finished via email. Due date applied 14 days after billing was issued.</p>
           </div>
         </div>
+
+        <!-- faq 8 -->
+        <div class="border-b border-b-gray-300 py-3.5">
+          <button class="accordion font-bold text-gray-800 text-lg leading-7 text-left w-full flex items-center justify-between" style="transition: 0.4s;">
+            <span class="w-11/12 md:w-full">How much is the cost of bandwidth or viewer minutes?</span>
+          </button>
+          <div class="panel overflow-hidden text-left text-gray-600">
+            <p class="text-base leading-6 mt-3.5 mr-5 lg:mr-[3.75rem]">The bandwidth and viewer minutes is the biggest factor in live streaming cost, we're working to make this more affordable so small startups and indie hackers can afford to build a live streaming app. In the meantime, the bandwidth or viewer minutes is free during beta.</p>
+          </div>
+        </div>
     </div>
   </section>
 


### PR DESCRIPTION
**Description**
This covers issue #123 that we need to update the FAQ on the pricing page with bandwidth pricing.

**Implementation**
- Adding 1 row FAQ with content : 
```
How much is the cost of bandwidth or viewer minutes?
The bandwidth and viewer minutes is the biggest factor in live streaming cost, we're working to make this more affordable so small startups and indie hackers can afford to build a live streaming app. In the meantime, the bandwidth or viewer minutes is free during beta.
```