### PR TITLE
Style : Adjustment on FAQ Content Pricing Page 

### DIFF
--- a/themes/inlive/layouts/page/pricing.html
+++ b/themes/inlive/layouts/page/pricing.html
@@ -152,16 +152,6 @@
         <!-- faq 7 -->
         <div class="border-b border-b-gray-300 py-3.5">
           <button class="accordion font-bold text-gray-800 text-lg leading-7 text-left w-full flex items-center justify-between" style="transition: 0.4s;">
-            <span class="w-11/12 md:w-full">How can I know my billing?</span>
-          </button>
-          <div class="panel overflow-hidden text-left text-gray-600">
-            <p class="text-base leading-6 mt-3.5 mr-5 lg:mr-[3.75rem]">We will send you a billing statement after 1 cycle (30 days) has been finished via email. Due date applied 14 days after billing was issued.</p>
-          </div>
-        </div>
-
-        <!-- faq 8 -->
-        <div class="border-b border-b-gray-300 py-3.5">
-          <button class="accordion font-bold text-gray-800 text-lg leading-7 text-left w-full flex items-center justify-between" style="transition: 0.4s;">
             <span class="w-11/12 md:w-full">What if my quota has been exceeded before the end of the cycle?</span>
           </button>
           <div class="panel overflow-hidden text-left text-gray-600">
@@ -169,7 +159,7 @@
           </div>
         </div>
 
-        <!-- faq 9 -->
+        <!-- faq 8 -->
         <div class="border-b border-b-gray-300 py-3.5">
           <button class="accordion font-bold text-gray-800 text-lg leading-7 text-left w-full flex items-center justify-between" style="transition: 0.4s;">
             <span class="w-11/12 md:w-full">What if my quota is still available but the cycle has ended?</span>


### PR DESCRIPTION
**Description**
This is related to the issue #156 .
We add 2 new information regarding renew feature on the FAQ pricing page.

**Implementation**
Add FAQ content
<img width="646" alt="Screen Shot 2022-08-24 at 14 01 26" src="https://user-images.githubusercontent.com/102952824/186353957-37353a1e-b292-4f31-be72-de5920849465.png">
