### PR TITLE
Documentation : Update The Return Props from Livestreaming Endpoints

### DIFF
--- a/content/docs/tutorial/app-with-webrtc/index.md
+++ b/content/docs/tutorial/app-with-webrtc/index.md
@@ -121,7 +121,7 @@ Since we've already made a create stream function, then when we click on the `Cr
         "prepared_at": null,
         "updated_by": null,
         "updated_at": "2022-02-22T10:51:31.050747Z",
-        "quality": "360",
+        "quality": "360"
     }
 }
 ```
@@ -350,7 +350,7 @@ The API response will return data like this:
         "updated_by": null,
         "updated_at": "2022-09-06T02:38:50.746014Z",
         "quality": "360",
-        "viewer_count": 0,
+        "viewer_count": 0
     }
 }
 ```


### PR DESCRIPTION
**Description**
This is solved issue #160 .
Since we have some new features, we need too adjust the information on the livestream endpoint return on the [tutorial with WebRTC inlive-website documentation](https://inlive.app/docs/tutorial/tutorial-app-with-webrtc/) because there are some additional properties. This affecting 2 return data endpoints on the tutorial :
- Return data of create stream `/streams/create` endpoint
- Return data of get specific stream `/streams/{id}` endpoint

**Implementation**
- Updating return data of create stream `/streams/create` endpoint
<img width="1049" alt="Screen Shot 2022-09-06 at 10 41 48" src="https://user-images.githubusercontent.com/102952824/188542856-fa561295-4275-4121-bd57-ec1454c6fc87.png">


- Updating return data of get specific stream `/streams/{id}` endpoint
<img width="994" alt="Screen Shot 2022-09-06 at 10 42 00" src="https://user-images.githubusercontent.com/102952824/188542875-c3b74217-af54-4ce1-9c44-d95c812a825d.png">
