### PR TITLE
feat: update pricing plan data

### DIFF
--- a/themes/inlive/layouts/page/pricing.html
+++ b/themes/inlive/layouts/page/pricing.html
@@ -28,7 +28,7 @@
     <div class="bg-emerald-100 border border-emerald-300 w-full sm:w-2/3 rounded-lg py-4 sm:py-6 px-4 sm:px-6">
       <p class="text-emerald-800 leading-6 sm:leading-7 font-medium text-center">
         You can get a free 1 month of business plan coupon.
-        <b><a href="https://docs.google.com/forms/d/e/1FAIpQLScdo7fm1XbfaW9_O59IqU2GX7qy9f6huZBybWLMnsY_rML66A/viewform" class="underline" target="_blank" rel="noopener noreferrer" data-tracking-event="open-link" data-tracking-label="1 month of business plan form at pricing page">Fill out this form </a></b> to check if you're eligible. During our beta, our streaming quota <b>will still use streaming hours</b> as metrics, not bandwidth.
+        <b><a href="https://docs.google.com/forms/d/e/1FAIpQLScdo7fm1XbfaW9_O59IqU2GX7qy9f6huZBybWLMnsY_rML66A/viewform" class="underline" target="_blank" rel="noopener noreferrer" data-tracking-event="open-link" data-tracking-label="1 month of business plan form at pricing page">Fill out this form </a></b> to check if you're eligible.
       </p>
     </div>
   </section>
@@ -36,7 +36,7 @@
       <div class="grid overflow-x-auto gap-5" style="grid-template-columns: repeat(4, 1fr);">
         {{ $linkStudioOrigin := getenv "_HUGO_INLIVE_STUDIO_ORIGIN" }}
         {{ $apiOriginLink := getenv "_HUGO_INLIVE_API_ORIGIN"}}
-        {{ $linkAPI := printf "%s/v1/package/" $apiOriginLink }}
+        {{ $linkAPI := printf "%s/v1/package" $apiOriginLink }}
         {{ $items := getJSON $linkAPI }}
         {{ range $item := sort $items.data "id" "asc"}}
         <div class="text-center w-[280px] border border-gray-300 rounded-2xl min-h-[586px]">


### PR DESCRIPTION
# Description
This PR will resolve #175. This PR covers the pricing plan update based on [the launching price sheet](https://docs.google.com/spreadsheets/d/1zFUFVe5QxSv0UrR-XzPFqEr5yoHdNnimKfLXCZ6-vnw/edit#gid=2121423168).

- Update the pricing plan table and add additional descriptions for each pricing plan.
- Update information about beta below pricing page heading and provide a link that persuades the user to get free 1 month of business plan by filling the beta form.
- Add mixpanel tracking on beta form link
- Remove outdated copywriting about providing all users with business plan for free on FAQ.

Preview URL: https://fix-update-pricing.inlive-website.pages.dev/pricing/