### PR TITLE
feat: add links on the footer

### DIFF
--- a/themes/inlive/layouts/partials/footer/footer.html
+++ b/themes/inlive/layouts/partials/footer/footer.html
@@ -23,6 +23,12 @@
         <li class="text-sm leading-6">
           <a href="/docs/introduction/" class="text-gray-500" data-tracking-event="open-link" data-tracking-label="Docs navigation link on the footer">Docs</a>
         </li>
+        <li class="text-sm leading-6">
+          <a href="https://github.com/orgs/inlivedev/discussions" class="text-gray-500" data-tracking-event="open-link" data-tracking-label="Discussion navigation link on the footer" target="_blank" rel="noopener noreferrer">Discussion</a>
+        </li>
+        <li class="text-sm leading-6">
+          <a href="https://api.inlive.app/apidocs" class="text-gray-500" data-tracking-event="open-link" data-tracking-label="API References navigation link on the footer" target="_blank" rel="noopener noreferrer">API References</a>
+        </li>
       </ul>
     </nav>
     <nav class="flex-1 lg:max-w-[240px]">


### PR DESCRIPTION
Add GitHub discussion and inlive API reference links on the footer

Preview link: https://feat-add-footer-links.inlive-website.pages.dev