### PR TITLE
feat: enable clarity analytics

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,7 @@ _HUGO_INLIVE_API_ORIGIN=https://dev-api.inlive.app
 
 # Analytics
 _HUGO_MIXPANEL_PROJECT_TOKEN=
+_HUGO_CLARITY_TRACKING_ID=
 
 # Email
 _HUGO_INLIVE_EMAIL=hello@inlive.app

--- a/themes/inlive/layouts/partials/head/analytics.html
+++ b/themes/inlive/layouts/partials/head/analytics.html
@@ -29,3 +29,15 @@
   });
   </script>
 {{ end }}
+
+<!-- Clarity Analytics -->
+{{ $clarityID := getenv "_HUGO_CLARITY_TRACKING_ID" }}
+{{ if gt (len $clarityID) 0 }}
+<script type="text/javascript">
+  (function(c,l,a,r,i,t,y){
+      c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+      t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+      y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+  })(window, document, "clarity", "script", "{{ $clarityID }}");
+</script>
+{{ end }}


### PR DESCRIPTION
# Description
This PR will enable the clarity analytics again after it was removed on this PR #166. I already added the clarity ID for dev and prod in the cloudflare pages env.

Preview link: https://feat-enable-clarity-analytic.inlive-website.pages.dev