### PR TITLE
feat: add playsinline attribute in video

### DIFF
--- a/themes/inlive/layouts/page/realtime-interactive.html
+++ b/themes/inlive/layouts/page/realtime-interactive.html
@@ -31,7 +31,7 @@
         </div>
         <div class="flex-1 flex justify-center lg:justify-end">
           <div class="max-w-xs lg:max-w-xl w-full aspect-square">
-            <video autoplay muted loop class="w-full h-full">
+            <video autoplay loop muted playsinline class="w-full h-full">
               <source src="/videos/realtime-interactive/inlive-hub.webm" type="video/webm">
               <source src="/videos/realtime-interactive/inlive-hub.mp4" type="video/mp4">
             </video>


### PR DESCRIPTION
Add playsinline attribute to fix video not autoplaying in ios safari